### PR TITLE
#6270:  diff coderay malformed in the "news" page

### DIFF
--- a/app/views/news/edit.rhtml
+++ b/app/views/news/edit.rhtml
@@ -12,3 +12,7 @@
                    }, :accesskey => accesskey(:preview) %>
 <% end %>
 <div id="preview" class="wiki"></div>
+
+<% content_for :header_tags do %>
+  <%= stylesheet_link_tag 'scm' %>
+<% end %>

--- a/app/views/news/index.rhtml
+++ b/app/views/news/index.rhtml
@@ -45,6 +45,7 @@
 
 <% content_for :header_tags do %>
   <%= auto_discovery_link_tag(:atom, params.merge({:format => 'atom', :page => nil, :key => User.current.rss_key})) %>
+  <%= stylesheet_link_tag 'scm' %>
 <% end %>
 
 <% html_title(l(:label_news_plural)) -%>


### PR DESCRIPTION
Hi Eric,

This patch just adds the scm.css to the news pages to allow syntax highlighting.

--Holger
