### PR TITLE
Fix faiing test, see http://ci.finn.de/builds/1-8-7_redmine-trunk_postgres/4100

### DIFF
--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -400,7 +400,7 @@ class QueryTest < ActiveSupport::TestCase
                                [group1.name, group1.id],
                                [group2.name, group2.id]
                               ]
-        assert_equal expected_group_list, @query.available_filters["member_of_group"][:values]
+        assert_equal expected_group_list.sort, @query.available_filters["member_of_group"][:values].sort
       end
 
     end


### PR DESCRIPTION
Hi Eric, this simple patch makes the check of the test "#available_filters 'member_of_group' filter should have a list of the groups as values." deterministic.
