### PR TITLE
Issue/6788 format date accepts no string argument

### DIFF
--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -37,7 +37,8 @@ module Redmine
 
     def format_date(date)
       return nil unless date
-      Setting.date_format.blank? ? ::I18n.l(date.to_date, :count => date.strftime('%d')) : date.strftime(Setting.date_format)
+      date = date.to_time if date.is_a?(String)
+      Setting.date_format.blank? ? ::I18n.l(date, :count => date.strftime('%d')) : date.strftime(Setting.date_format)
     end
     
     def format_time(time, include_date = true)

--- a/test/unit/lib/redmine/i18n_test.rb
+++ b/test/unit/lib/redmine/i18n_test.rb
@@ -37,6 +37,7 @@ class Redmine::I18nTest < ActiveSupport::TestCase
     today = Date.today
     Setting.date_format = '%d %m %Y'
     assert_equal today.strftime('%d %m %Y'), format_date(today)
+    assert_equal today.strftime('%d %m %Y'), format_date(today.to_s)
   end
   
   def test_date_and_time_for_each_language


### PR DESCRIPTION
Hi Eric,

this patch allows format_date to accept strings again. It is required by at least your `redmine_project_support_hours` according to rchady on IRC.

This patch fixes [#6788](http://www.redmine.org/issues/6788).

--Holger
