### PR TITLE
i18n: fix notice_failed_to_save_issues in es, gl and ca locales

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -161,7 +161,7 @@ ca:
   notice_email_error: "S'ha produït un error en enviar el correu (%{value})"
   notice_feeds_access_key_reseted: "S'ha reiniciat la clau d'accés del RSS."
   notice_api_access_key_reseted: "S'ha reiniciat la clau d'accés a l'API."
-  notice_failed_to_save_issues: "No s'han pogut desar %s assumptes de %{count} seleccionats: %{ids}."
+  notice_failed_to_save_issues: "No s'han pogut desar %{count} assumptes de %{total} seleccionats: %{ids}."
   notice_failed_to_save_members: "No s'han pogut desar els membres: %{errors}."
   notice_no_issue_selected: "No s'ha seleccionat cap assumpte. Activeu els assumptes que voleu editar."
   notice_account_pending: "S'ha creat el compte i ara està pendent de l'aprovació de l'administrador."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -677,7 +677,7 @@ es:
   notice_default_data_loaded: Configuración por defecto cargada correctamente.
   notice_email_error: "Ha ocurrido un error mientras enviando el correo (%{value})"
   notice_email_sent: "Se ha enviado un correo a %{value}"
-  notice_failed_to_save_issues: "Imposible grabar %s peticion(es) en %{count} seleccionado: %{ids}."
+  notice_failed_to_save_issues: "Imposible grabar %{count} peticion(es) de %{total} seleccionada(s): %{ids}."
   notice_feeds_access_key_reseted: Su clave de acceso para RSS ha sido reiniciada.
   notice_file_not_found: La página a la que intenta acceder no existe.
   notice_locking_conflict: Los datos han sido modificados por otro usuario.

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -654,7 +654,7 @@ gl:
   notice_default_data_loaded: Configuración por defecto cargada correctamente.
   notice_email_error: "Ocorreu un error enviando o correo (%{value})"
   notice_email_sent: "Enviouse un correo a %{value}"
-  notice_failed_to_save_issues: "Imposible gravar %s petición(s) en %{count} seleccionado: %{ids}."
+  notice_failed_to_save_issues: "Imposible gravar %{count} petición(s) de %{total} seleccionada(s): %{ids}."
   notice_feeds_access_key_reseted: A súa clave de acceso para RSS reiniciouse.
   notice_file_not_found: A páxina á que tenta acceder non existe.
   notice_locking_conflict: Os datos modificáronse por outro usuario.


### PR DESCRIPTION
Without this, when an issue cannot be copied it raises (spanish):

<pre>I18n::MissingInterpolationArgument (missing interpolation argument in "Imposible grabar %{value} peticion(es) en %{count} seleccionado: %{ids}." ({:count=>"1", :total=>"1", :ids=>"#22989"} given))</pre>
