### PR TITLE
Solve autologging issue

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -235,6 +235,8 @@ class Changeset < ActiveRecord::Base
   def log_time_activity
     if Setting.commit_logtime_activity_id.to_i > 0
       TimeEntryActivity.find_by_id(Setting.commit_logtime_activity_id.to_i)
+    else
+      TimeEntryActivity.find_by_name("Development")
     end
   end
 


### PR DESCRIPTION
According to http://www.redmine.org/boards/2/topics/22692?r=23334#message-23334
even when Setting.commit_logtime_enabled is set to true, when the commit
message contains log time (ex. @12m), it is not being logged at all.

The problem causes (changset.rb#237) line:

>    time_entry.activity = log_time_activity unless log_time_activity.nil?

log_time_activity is always nil (on clean setup) so the time_entry object
is not valid.

Solution is simple, adding to log_time_activity "else" statement:

>    else
>      TimeEntryActivity.find_by_name("Development")

That results in setting Development as default activity. If "Development"
activity does not exist, method returns nil and the logic stays the
same as before the changes.

Why treat "Development" as a Default activity ?
Most commits are "Development" ones, because "Support" or "Design" tasks
are rarely executed in the code; users rather choose to log them using
redmine UI.
