### PR TITLE
Autologging issue after discussion

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -235,6 +235,9 @@ class Changeset < ActiveRecord::Base
   def log_time_activity
     if Setting.commit_logtime_activity_id.to_i > 0
       TimeEntryActivity.find_by_id(Setting.commit_logtime_activity_id.to_i)
+    else
+      return TimeEntryActivity.default unless TimeEntryActivity.default.nil?
+      TimeEntryActivity.first
     end
   end
 

--- a/app/views/settings/_repositories.rhtml
+++ b/app/views/settings/_repositories.rhtml
@@ -34,7 +34,7 @@
          :onclick => "if (this.checked) { Form.Element.enable('settings_commit_logtime_activity_id'); } else { Form.Element.disable('settings_commit_logtime_activity_id'); }"%></p>
 
 <p><%= setting_select :commit_logtime_activity_id, 
-         [[l(:label_default), 0]] + TimeEntryActivity.shared.all.collect{|activity| [activity.name, activity.id.to_s]},
+         TimeEntryActivity.shared.all.collect{|activity| [activity.name, activity.id.to_s]} + [[l(:label_default), 0]],
          :disabled => !Setting.commit_logtime_enabled?%></p>
 </fieldset>
 


### PR DESCRIPTION
Referencing to https://github.com/edavis10/redmine/pull/29 discussion here are changes applied
to end problems with the time autologging feature (mainly on clean setups).

Steps taken:

First, changing "Default activity for autologging" list order by placing "Default" option
at the end. The change forces users' awareness of choosing the activity for
commit messages (see discussion above).

And second, changing activity selection fallback flow (from none to one providing some logic):

1) Select activity set in administration area
   .. if "Default" is choosen then ..
2) Select first default enumeration
   .. if no enumeration is set to default then ..
3) Select first activity from database
