### PR TITLE
Autofetch once on adding repo (if global autofetch is off). 

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -54,6 +54,7 @@ class RepositoriesController < ApplicationController
       @repository.attributes = p
       @repository.merge_extra_info(p_extra)
       @repository.save
+      @repository.fetch_changesets
     end
     render(:update) do |page|
       page.replace_html "tab-content-repository",


### PR DESCRIPTION
If global autofetch is off for repositories, adding a repo will not fetch until external command invoked. In my case, until push to that repo (I use post-recieve hook in git). So I want to autofetch after adding repo to have actual repository state in redmine.