### PR TITLE
Added option to specify project identifier.

### DIFF
--- a/extra/svn/Redmine.pm
+++ b/extra/svn/Redmine.pm
@@ -386,9 +386,8 @@ sub get_project_identifier {
     my $location = $r->location;
     my $identifier;
 
-    if($cfg->{RedmineProjectId}) {        
-        $location =~ /([^\/]+)\Z/;
-	$identifier = $1
+    if($cfg->{RedmineProjectId}) {
+	$identifier = $cfg->{RedmineProjectId};
     } else {
         $identifier = $r->uri =~ m{$location/*([^/]+)};
     }


### PR DESCRIPTION
According to the Redmine.pm descripition (http://www.redmine.org/projects/redmine/wiki/Repositories_access_control_with_apache_mod_dav_svn_and_mod_perl), if the repositories are not created automatically by reposman.rb, it is important that the repository name is the same as the project identifier in Redmine, otherwise Redmine.pm will fail to authenticate users. For example, if the path to the repository is /path/to/repository/foo-bar, then the project Identifier on the Settings page must be foo-bar.

This is a little bit incombinient, so I added option to assign any project identifier.
