### PR TITLE
"<br />" should be inserted before {{macro}}.

### DIFF
--- a/lib/redmine/wiki_formatting/textile/formatter.rb
+++ b/lib/redmine/wiki_formatting/textile/formatter.rb
@@ -43,7 +43,7 @@ module Redmine
         # Patch for RedCloth.  Fixed in RedCloth r128 but _why hasn't released it yet.
         # <a href="http://code.whytheluckystiff.net/redcloth/changeset/128">http://code.whytheluckystiff.net/redcloth/changeset/128</a>
         def hard_break( text )
-          text.gsub!( /(.)\n(?!\n|\Z| *([#*=]+(\s|$)|[{|]))/, "\\1<br />" ) if hard_breaks
+          text.gsub!( /(.)\n(?!\n|\Z| *([#*=]+(\s|$)|\{[^{]|\|))/, "\\1<br />" ) if hard_breaks
         end
 
         # Patch to add code highlighting support to RedCloth


### PR DESCRIPTION
&lt;br /&gt; tag is not inserted before macros in Wiki.

For example,

<pre>
abc
{{hello_world}}
</pre>

should be converted to

<pre>
&lt;p&gt;abc&lt;br /&gt;Hello world! Object: Journal, Called with no argument.&lt;/p&gt;
</pre>


However, it is converted to

<pre>
&lt;p&gt;abc
Hello world! Object: Journal, Called with no argument.&lt;/p&gt;
</pre>


This patch solves this issue.

For more detail, please refer to issue #9377, http://www.redmine.org/issues/9377.
