### PR TITLE
fix comparison of Symbol with Arel::Table failed exception when update wiki contents

### DIFF
--- a/lib/plugins/acts_as_versioned/lib/acts_as_versioned.rb
+++ b/lib/plugins/acts_as_versioned/lib/acts_as_versioned.rb
@@ -435,7 +435,7 @@ module ActiveRecord #:nodoc:
           # Gets the next available version for the current record, or 1 for a new record
           def next_version
             return 1 if new_record?
-            (versions.calculate(:max, :version) || 0) + 1
+            (versions.maximum(:version) || 0) + 1
           end
 
           # clears current changed attributes.  Called after save.


### PR DESCRIPTION
when I try to update a wiki content in redmine 2, it throws exception 
ArgumentError (comparison of Symbol with Arel::Table failed):
  lib/plugins/acts_as_versioned/lib/acts_as_versioned.rb:438:in `next_version'
  lib/plugins/acts_as_versioned/lib/acts_as_versioned.rb:432:in`set_new_version'
  app/controllers/wiki_controller.rb:152:in `update'

This should use maximum not calculate :max
