### PR TITLE
Fixed token key regex issue

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -41,7 +41,7 @@ class Token < ActiveRecord::Base
   def self.find_active_user(action, key, validity_days=nil)
     action = action.to_s
     key = key.to_s
-    return nil unless action.present? && key =~ /\A[a-f0-9]+\z/
+    return nil unless action.present? && !key.match('\A[a-zA-Z0-9]+\Z').nil?
 
     token = find_by_action_and_value(action, key)
     if token && token.user && token.user.active?


### PR DESCRIPTION
I had problems with the following regex:

```
key =~ /\A[a-f0-9]+\z/
```
- On a match the index is returned but an index of zero == false.
- The range "a-f" is not enough
