### PR TITLE
Possible string to symbol comparison

### DIFF
--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -148,7 +148,7 @@ module Redmine
 
         def init_translations(locale)
           locale = locale.to_s
-          paths = ::I18n.load_path.select {|path| File.basename(path, '.*') == locale}
+          paths = ::I18n.load_path.select {|path| File.basename(path, '.*') == locale.to_s}
           load_translations(paths)
           translations[locale] ||= {}
         end


### PR DESCRIPTION
When "locale" is a symbol the comparison to the translation file name will always return false (tested on ruby 1.8.7 windows build).

This will cause translations file to not load.
