### PR TITLE
When 2 projects happened to be created in the same time, new projects won't be created.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -688,7 +688,7 @@ class Project < ActiveRecord::Base
 
   # Returns an auto-generated project identifier based on the last identifier used
   def self.next_identifier
-    p = Project.order('created_on DESC').first
+    p = Project.order('id DESC').first
     p.nil? ? nil : p.identifier.to_s.succ
   end
 


### PR DESCRIPTION
I run into a situation today. I couldn't create new projects in redmine. 

After looking into the code, I found that it is a bug in Project.next_identifier. 
When 2 projects happened to be created in the same time, the Project.next_identifier would generate duplicate identifier, which in turn would fail the new project creation.

Btw, I like redmine very much. Thank you guys for your effort to make it so wonderful!
